### PR TITLE
Add write permissions to the workflow

### DIFF
--- a/.github/workflows/loc_workflow.yml
+++ b/.github/workflows/loc_workflow.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 23 * * 0"  # Runs every day at 11:00 PM UTC
   workflow_dispatch:  # Allows manual triggering from GitHub UI
 
+permissions:
+    contents: write
+    
 jobs:
   count-loc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/loc_workflow.yml` file. The change adds permissions to allow writing contents in the workflow.

Changes to workflow permissions:

* [`.github/workflows/loc_workflow.yml`](diffhunk://#diff-bc2b69a6ef9a90a6cfe279737fb08cc87439807632794d2ecb2851089074f247R8-R10): Added `permissions` to allow writing contents in the workflow.